### PR TITLE
Add more details option on search route

### DIFF
--- a/react/src/App.js
+++ b/react/src/App.js
@@ -9,6 +9,7 @@ import './App.css';
 import Header from "./components/Header";
 import Footer from "./components/Footer"
 import Graph from "./components/Graph";
+import DynamicInfo from "./components/DynamicInfo";
 
 function App() {
 
@@ -49,6 +50,7 @@ function App() {
         <Route path="/current-location">
           <CurrentLocation />
         </Route>
+        <Route path="/details/:cityName" render={(props) => <DynamicInfo info={props}/>} />
       </Switch>
       <Footer/>
     </Router>

--- a/react/src/components/DynamicInfo.js
+++ b/react/src/components/DynamicInfo.js
@@ -1,0 +1,50 @@
+import React, {useState,useEffect} from 'react';
+import axios from 'axios';
+import Details from "./Details";
+import Graph from "./Graph";
+
+const container={
+    display:"flex",
+    marginTop:"120px",
+    flexDirection:"column",
+    justifyContent:"center",
+    alignItems:"center",
+    color:"red",
+}
+
+const DynamicInfo = (props) => {
+    const [cityData,setCityData] = useState({city:'',lat:'',lon:''});
+    const [weather, setWeather] = useState({});
+    const city = props.info.match.params.cityName;
+    const url = `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=77f89854c57f52abf424c8eb9b13714c`;
+    // console.log(props.info);
+
+    useEffect(()=>{
+        axios.get(url)
+        .then(res => {
+          const currData = res.data;
+          setWeather(currData);
+          setCityData({city:city,lat:currData.coord.lat,lon:currData.coord.lon})
+        //   console.log(res);
+        });
+    },[city,url]);
+
+    
+
+    return (
+        <div>
+    <div className="bg-image" style={container}>
+    <div className="header">
+        <h1 className="city-name">{city}</h1>
+    </div>
+    <div className="weather-info">
+        <Details data={weather} />
+        {console.log(weather)}
+    </div>
+    </div>
+    <Graph cityData={cityData} />
+    </div>
+    )
+}
+
+export default DynamicInfo;

--- a/react/src/components/GetLoaction.js
+++ b/react/src/components/GetLoaction.js
@@ -16,7 +16,7 @@ class GetLoaction extends Component {
           navigator.geolocation.getCurrentPosition(resolve, reject);
         });
       }
-    
+      // 77f89854c57f52abf424c8eb9b13714c
       setCity = () => {
         Axios.get(`https://api.openweathermap.org/data/2.5/weather?lat=${this.state.Latitude}&lon=${this.state.Longitude}&appid=77f89854c57f52abf424c8eb9b13714c`)
         .then( res => {
@@ -26,6 +26,7 @@ class GetLoaction extends Component {
           });
           // Sets City data in App.js
           this.props.changeGlobalCityData({city: this.state.city, lat:this.state.Latitude, lon:this.state.Longitude});
+          // console.log(this.state.city);
         })
       }
     

--- a/react/src/components/Search.css
+++ b/react/src/components/Search.css
@@ -171,6 +171,7 @@ body {
   /* padding-top: 270px; */
   /* width:100%; */
   /* height:300px; */
+  margin-top: 30px;
   text-align: center;
   color: white;
 }
@@ -185,4 +186,11 @@ body {
   list-style: inline;
   list-style-type: none;
   word-spacing: 120%;
+}
+
+#details .moreInfo{
+  text-align: right;
+  padding-bottom: 20px;
+  padding-right: 10px;
+  color: #000000;
 }

--- a/react/src/components/Search.js
+++ b/react/src/components/Search.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import {Link} from 'react-router-dom';
 import "./Search.css";
 
 class Search extends Component{
@@ -53,11 +54,11 @@ class Search extends Component{
   }
   render(){
     return (
-    <div class="container">
-    <div class="search-box">
+    <div className="container">
+    <div className="search-box">
       <h2>Search by City Name</h2>
       <form>
-        <div class="user-box">
+        <div className="user-box">
           <input type="text" value={this.state.city} onChange={this.onChange}/>
           <label>City</label>
         </div>
@@ -70,7 +71,7 @@ class Search extends Component{
         </a>
       </form>
     </div>
-    <div class="display">
+    <div className="display">
       <div id="details">
         <h1>{this.state.details.name}</h1>
         <img src={this.state.imgurl} alt="sun"></img>
@@ -79,6 +80,9 @@ class Search extends Component{
         <li>{this.state.result.description}</li>
         <li>humidity: {this.state.humidity}</li>
         </ul>
+        <div className="moreInfo">
+          <Link to={`/details/${this.state.details.name}`}>More Details...</Link>
+        </div>
       </div>
     </div>
     </div>


### PR DESCRIPTION
# Pull Request 
It seems like the API key in the code has crossed its limit of request so the data is not shown on the home and the search route.(STATUS 429: too many requests).
When I used my own API key it worked fine.

## Proposed Changes
- I have added a **More Details** option on the information displayed on the search route. When it is clicked then we are redirected to a dynamic route ( **/details/:cityName** ) where the full information along with the graphs is given about the searched city.

- Fixes #32 

## Types of changes made
- [X] Fixed Bug
- [X] Added new Features
- [ ] Edited Documentations
- [ ] Enhanced the working of code
- [ ] Additional Changes
- *Mention any Additional Change here*
## Additional Info
Please change the API key to see the changes I have made. However I have attached screenshots also.
## Screenshots 
![sc1](https://user-images.githubusercontent.com/53096435/96386030-74b98480-11b5-11eb-8449-40980fe70dda.png)
![sc2](https://user-images.githubusercontent.com/53096435/96386032-771bde80-11b5-11eb-9cfc-fbb1ea1c7117.png)
![sc3](https://user-images.githubusercontent.com/53096435/96386036-78e5a200-11b5-11eb-9d85-c06a32deb430.png)

## Checklist:
- [X] My code follows the Mentioned Guidelines for the project
- [X] I have self-reviewed the changes made
- [ ] I have made the changes easy to understand by adding comments
- [X] My changes does not generate new warnings/errors
- [X] I have attached relevant screenshots to display the changes made
- [ ] I have made the required changes to the documentations
